### PR TITLE
Downgrade Docker Compose file format to 3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: "3.9"
+version: "3.7"
 
 services:
   airflow:


### PR DESCRIPTION
Resolves a problem encountered by @geojayuu when running Docker Compose on Ubuntu.

See [this Slack thread](https://mapaction.slack.com/archives/CKF3LQGGL/p1619345591008900?thread_ts=1619278153.008000&cid=CKF3LQGGL) for details (MapAction internal).