### PR TITLE
Replace `gsutil cp` with `gsutil rsync -d`

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -23,6 +23,6 @@ jobs:
           project_id: ${{ secrets.GCS_PROJECT }}
           export_default_credentials: true
       - name: Copy DAGs
-        run: gsutil cp -r ./dags gs://${{ secrets.GCLOUD_BUCKET_PATH }}/
+        run: gsutil rsync -d -r ./dags gs://${{ secrets.GCLOUD_BUCKET_PATH }}/
       - name: Copy plugins
-        run: gsutil cp -r ./plugins gs://${{ secrets.GCLOUD_BUCKET_PATH }}/
+        run: gsutil rsync -d -r ./plugins gs://${{ secrets.GCLOUD_BUCKET_PATH }}/


### PR DESCRIPTION
Recent refactoring of the DAGs resulted in the removal of the file `dags.py` from the repo. This file was left orphaned on GCP where it is still loaded by Composer. This resulted with the code that Composer was attempting to load was in a inconsistent state and hence failed to load properly.

By switching from `gsutil cp` to `gsutil rsync -d` we guarantee to remove old orphaned files on GCP and ensure that the code available to Composer is identical to the `master` branch of the repo.