### PR TITLE
Added note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ $ docker compose build airflow
 
 **Note:** This image is approx ~2GB in size.
 
+**Note:** Instead of `docker compose` you can alternatively run `docker-compose` using the docker-compose binary.
 ### Local usage
 
 To start the Airflow server:

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ $ docker compose build airflow
 
 **Note:** This image is approx ~2GB in size.
 
-**Note:** Instead of `docker compose` you can alternatively run `docker-compose` using the docker-compose binary.
+**Note:** On Linux you will need to use `docker-compose` (with a hyphen) instead of `docker compose` (for MacOS and Windows).
+
 ### Local usage
 
 To start the Airflow server:


### PR DESCRIPTION
For some mysterious reasons `docker compose` didn't work for me while `docker-compose` worked perfectly fine. Apparently both options are legal. I've added a small note suggesting that you could alternatively use `docker-compose` instead of the initial command. 

The purpose of this tiny commit is to verify that I have all necessary permissions to work with the pipeline repo. 