### PR TITLE
Create new_airflow_environment.yml

### DIFF
--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -1,0 +1,40 @@
+name: New_Airflow_Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      newComposerEnvName:
+        description: 'Name for the new Google Cloud Composer Environment (Airflow instance)'
+        required: true
+
+jobs:
+  create-new-env:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Google Cloud Utilities
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCLOUD_SERVICE_KEY }}
+          project_id: ${{ secrets.GCS_PROJECT }}
+          export_default_credentials: true
+      - name: Create New Environment
+        # run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515 --machine-type=n1-standard-2
+        run: gcloud composer environments describe ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515
+      - name: Get URL of new DAG bucket full path
+        id: dag_path
+        run: echo "::set-output name=dag_url::gcloud.cmd composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object"
+      - name: Get URL of new DAG bucket root
+        id: bucket_root
+        run: |
+          url=$(python -c "import re; print(re.search('(gs:.+\/)(dags$)', r'${{ steps.dag_path.outputs.dag_url }}').group(1))")
+          echo "::set-output name=bucket_url::$url"
+      - name: Update DAG bucket secret
+        run: echo ${{ steps.bucket_root.outputs.dag_url }}
+      #   uses: hmanzur/actions-set-secret@v2.0.0
+      #   with:
+      #     name: 'GCLOUD_BUCKET_PATH'
+      #     value: ${{ steps.bucket_root.outputs.dag_url }}
+      #     repository: ${{ env.GITHUB_REPOSITORY	}}
+      #     token: ${{ secrets.REPO_ACCESS_TOKEN }}


### PR DESCRIPTION
This is an initial attempt to create a GH Action workflow that will create a new Google Cloud Composer instance and then configure the repo to deploy to the new instance.

GCP Composer names each instance of Airflow and its associated K8s nodes an "Environment". A new environment can be created with the command:
```gcloud composer create ...```
When you create a new Environment, you cannot specify which bucket it will read the DAGs from. It will create a new bucket (with an incomprehensible name). You then need to query the URL of the new bucket and add it as the value of the GCLOUD_BUCKET_PATH secret.
```gcloud composer environments describe --location=europe-west2 $new_composer_env_name --flatten=config.dagGcsPrefix```

I have not yet considered the required permissions on the new bucket.

There is a GitHub Action on the market place which claims to enable updating GH secrets programmatically. I have not yet tried this and would like to review the code before I do so.

