### PR TITLE
Debug GitHub Action to create new GCP Composer Environment

### DIFF
--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -37,10 +37,10 @@ jobs:
           url=$(python -c "import re; print(re.search('(gs:.+\/)(dags$)', r'${{ steps.dag_path.outputs.dag_url }}').group(1))")
           echo "::set-output name=bucket_url::${url}"
       - name: Update DAG bucket secret
-        run: echo ${{ steps.bucket_root.outputs.dag_url }}
+        run: echo ${{ steps.bucket_root.outputs.bucket_url }}
       #   uses: hmanzur/actions-set-secret@v2.0.0
       #   with:
       #     name: 'GCLOUD_BUCKET_PATH'
-      #     value: ${{ steps.bucket_root.outputs.dag_url }}
+      #     value: ${{ steps.bucket_root.outputs.bucket_url }}
       #     repository: ${{ env.GITHUB_REPOSITORY	}}
       #     token: ${{ secrets.REPO_ACCESS_TOKEN }}

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -26,7 +26,7 @@ jobs:
         id: dag_path
         run: |
           dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
-          echo ""::debug::$dagpath"
+          echo "::debug::$dagpath"
           echo "::set-output name=dag_url::$dagpath"
       - name: Get URL of new DAG bucket root
         id: bucket_root

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -20,8 +20,8 @@ jobs:
           project_id: ${{ secrets.GCS_PROJECT }}
           export_default_credentials: true
       - name: Create New Environment
-        # run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515 --machine-type=n1-standard-2
-        run: gcloud composer environments describe ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515
+        run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515 --machine-type=n1-standard-2
+        # run: gcloud composer environments describe ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515
       - name: Get URL of new DAG bucket full path
         id: dag_path
         run: |

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -26,9 +26,9 @@ jobs:
         id: dag_path
         run: |
           dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
-          echo "::debug::${{ dagpath }}"
+          echo "::debug::${{ $dagpath }}"
           echo "::set-output name=dag_url::$dagpath"
-        # echo "::debug::${{ $dagpath }}"
+        # echo "::debug::${{ dagpath }}"
         # echo "::debug::${dagpath}"
       - name: Get URL of new DAG bucket root
         id: bucket_root

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -1,4 +1,4 @@
-name: New_Airflow_Environment
+name: Create New GCP Composer Environment (Airflow instance)
 
 on:
   workflow_dispatch:
@@ -27,10 +27,7 @@ jobs:
         run: |
           dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
           echo "::debug::${dagpath}"
-          echo "::set-output name=dag_url::$dagpath"
-        # Did not work
-        # echo "::debug::${{ dagpath }}"
-        # echo "::debug::${{ $dagpath }}"
+          echo "::set-output name=dag_url::${dagpath}"
       - name: Get URL of new DAG bucket root
         id: bucket_root
         run: |

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -35,7 +35,7 @@ jobs:
         id: bucket_root
         run: |
           url=$(python -c "import re; print(re.search('(gs:.+\/)(dags$)', r'${{ steps.dag_path.outputs.dag_url }}').group(1))")
-          echo "::set-output name=bucket_url::$url"
+          echo "::set-output name=bucket_url::${url}"
       - name: Update DAG bucket secret
         run: echo ${{ steps.bucket_root.outputs.dag_url }}
       #   uses: hmanzur/actions-set-secret@v2.0.0

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -26,10 +26,11 @@ jobs:
         id: dag_path
         run: |
           dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
-          echo "::debug::${{ $dagpath }}"
+          echo "::debug::${dagpath}"
           echo "::set-output name=dag_url::$dagpath"
+        # Did not work
         # echo "::debug::${{ dagpath }}"
-        # echo "::debug::${dagpath}"
+        # echo "::debug::${{ $dagpath }}"
       - name: Get URL of new DAG bucket root
         id: bucket_root
         run: |

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -20,7 +20,7 @@ jobs:
           project_id: ${{ secrets.GCS_PROJECT }}
           export_default_credentials: true
       - name: Create New Environment
-        run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515 --machine-type=n1-standard-2
+        run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515 --machine-type=n1-standard-2 --zone=europe-west2-a
         # run: gcloud composer environments describe ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515
       - name: Get URL of new DAG bucket full path
         id: dag_path

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -26,7 +26,9 @@ jobs:
         id: dag_path
         run: |
           dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
-          echo "::debug::$dagpath"
+          echo "::debug::${{ dagpath }}"
+          echo "::debug::${{ $dagpath }}"
+          echo "::debug::${dagpath}"
           echo "::set-output name=dag_url::$dagpath"
       - name: Get URL of new DAG bucket root
         id: bucket_root

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -27,9 +27,9 @@ jobs:
         run: |
           dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
           echo "::debug::${{ dagpath }}"
-          echo "::debug::${{ $dagpath }}"
-          echo "::debug::${dagpath}"
           echo "::set-output name=dag_url::$dagpath"
+        # echo "::debug::${{ $dagpath }}"
+        # echo "::debug::${dagpath}"
       - name: Get URL of new DAG bucket root
         id: bucket_root
         run: |

--- a/.github/workflows/new_airflow_environment.yml
+++ b/.github/workflows/new_airflow_environment.yml
@@ -20,18 +20,18 @@ jobs:
           project_id: ${{ secrets.GCS_PROJECT }}
           export_default_credentials: true
       - name: Create New Environment
-        run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515 --machine-type=n1-standard-2 --zone=europe-west2-a
+        run: gcloud composer environments create ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project ${{ secrets.GCLOUD_PROJECT }} --machine-type=n1-standard-2 --zone=europe-west2-a --env-variables ENVIRONMENT=PRODUCTION --env-variables GCP=TRUE
         # run: gcloud composer environments describe ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project=datapipeline-295515
       - name: Get URL of new DAG bucket full path
         id: dag_path
         run: |
-          dagpath=$(gcloud composer environments describe --location=europe-west2 --project=datapipeline-295515 ${{ github.event.inputs.newComposerEnvName }} --flatten=config.dagGcsPrefix --format=object)
+          dagpath=$(gcloud composer environments describe ${{ github.event.inputs.newComposerEnvName }} --location=europe-west2 --project= ${{ secrets.GCLOUD_PROJECT }} --flatten=config.dagGcsPrefix --format=object)
           echo "::debug::${dagpath}"
           echo "::set-output name=dag_url::${dagpath}"
       - name: Get URL of new DAG bucket root
         id: bucket_root
         run: |
-          url=$(python -c "import re; print(re.search('(gs:.+\/)(dags$)', r'${{ steps.dag_path.outputs.dag_url }}').group(1))")
+          url=$(python -c "import re; print(re.search('gs:\/\/(.+)(\/dags$)', r'${{ steps.dag_path.outputs.dag_url }}').group(1))")
           echo "::set-output name=bucket_url::${url}"
       - name: Update DAG bucket secret
         run: echo ${{ steps.bucket_root.outputs.bucket_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ Please maintain both this file AND the README.md file.
 ## [Unreleased]
 
 ### Added
-
-* initial GitHub Actions for Continuous Integration (CI)
+- Changed to GitHub Actions:
+  * initial GitHub Actions for Continuous Integration (CI)
+  * A new GCP Composer Environment can now be creatd using GitHub Actions
 
 ### Changed
 ### Deprecated


### PR DESCRIPTION
This PR builds on #49 and debugs the GitHub Action which creates a new Composer Environment (aka managed Airflow instance) in Google Cloud Platform.

I am adding some of the relevant notes are here until I find a better location for them in the relevant files in the repo.

# Process
GCP Composer names each instance of Airflow and its associated K8s nodes an "Environment". A new environment can be created with the command:
```
gcloud composer create ...
```
The Action can only be manually triggered. When triggered it asks the user to input the name to be used for the new Composer Environment. There is no default value.

TODO: The value of `secrets.GCLOUD_COMPOSER_ENVIRONMENT` should be updated with the new name.

When you create a new Environment, you cannot specify which bucket it will read the DAGs from. It will create a new bucket (with an incomprehensible name). The URL of the new bucket is queried with this command:
```
gcloud composer environments describe --location=europe-west2 $new_composer_env_name --flatten=config.dagGcsPrefix
```
This gives the URL including the `/dags` suffix. The `/dags` suffix needs to be stripped off before the next step.

The `Configs` action (which deploys the dags and plugin code to the Airflow instance) uses the `GCLOUD_BUCKET_PATH` secret as the destination to deploy to. Therefore this action needs to update the value of the GCLOUD_BUCKET_PATH secret.

TODO: Update the value of `secret.GCLOUD_BUCKET_PATH`

# Open questions:

- [ ] It is possible to specify the version of Airflow in the new instance. One possibility is that this action parses the `requirements.txt` for `apache-airflow` and uses the version number specified there. Is this a sensible/sane/foolhardy idea?
- [ ] Given this action can incur significant cost, is it possible to limit who can run this action?
- [ ] What permissions does the service account, used by GH Actions, require on GCP to perform these tasks?
- [ ] Do we need to set permissions of the new bucket, or are the defaults appropriate?
- [ ] Do we trust the 3rd party GH Action https://github.com/hmanzur/actions-set-secret?
- [ ] Do we want to automatically trigger the `Container` and `Configs` actions on completion of this action?

# Removing old Composer Environment and DAG bucket
There is currently no Action that removes an old Composer Environment and DAG bucket. Here are some notes on the process. The command `gcloud composer delete...` does not remove the associated DAG bucket. Therefore this DAG bucket must be identified _before_ removing the relevant Composer Environment.
